### PR TITLE
The current format of this link is not supported any more.

### DIFF
--- a/src/_data/client.js
+++ b/src/_data/client.js
@@ -10,7 +10,7 @@ module.exports = {
         "state": "CO",
         "zip": "80206",
         "country": "US",
-        "mapLink": "https://goo.gl/maps/UAQn4vuGDiwv7DV39"
+        "mapLink": "https://maps.app.goo.gl/TEdS5KoLC9ZcULuQ6"
     },
     "socials": {
         "facebook": "https://www.facebook.com/",


### PR DESCRIPTION
This could end up in developers wasting their time trying to find the current link format of a google business profile.

Do the same for the other repos :D

for more info check: 
https://developers.googleblog.com/en/google-url-shortener-links-will-no-longer-be-available/#:~:text=Google%20URL%20Shortener%20links%20will,would%20continue%20serving%20existing%20URLs.