### PR TITLE
Comments on the template are now properly skipped by nunjucks

### DIFF
--- a/src/content/pages/_template.txt
+++ b/src/content/pages/_template.txt
@@ -22,9 +22,8 @@ eleventyComputed:
 
     <!-- Page HTML goes here, without a <main> wrapper. The <main> tag is already presented in layouts/base.html -->
 
-    <!-- If you want the page to have a "CTA", uncomment the line below -->
-
-    <!-- {% include 'sections/cta.html' %} -->
+    <!-- If you want the page to have a "CTA", remove the {# and #} below -->
+    {# {% include 'sections/cta.html' %} #}
 
 {% endblock %}
 


### PR DESCRIPTION
Nunjucks was not escaping the comments in the template file. Fixed with using nunjucks-style comment blocks.
{# {% include 'sections/cta.html' %} #}