### PR TITLE
Leave cabinets.jpg when remove-decap.js is run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2162,6 +2162,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.44",
 				"caniuse-lite": "^1.0.30001806",
@@ -5170,6 +5171,7 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -5245,6 +5247,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
@@ -5691,6 +5694,7 @@
 			"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.7.tgz",
 			"integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"posthtml-parser": "^0.11.0",
 				"posthtml-render": "^3.0.0"

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -5,10 +5,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-
     <title>Content Manager</title>
 </head>
 
@@ -18,7 +14,9 @@
     <!-- Decap CMS preview pane script -->
     <!-- Edit this script to customize the preview pane for your blog posts.  -->
     <!-- Documentation: https://decapcms.org/docs/customization/ -->
-    <script type="text/babel">
+    <script>
+        const { createClass, h } = window;
+
         const BlogPreview = createClass({
             render: function () {
                 // Get all the props from the collection
@@ -36,25 +34,25 @@
 
                 const cover = this.props.getAsset(image);
 
-                // Create elements for the preview pane in JSX, to be processed by Babel
-                return (
-                    <div className="blog">
-                        <h1 className="title">{title}</h1>
-
-                        <div className="metadata">
-                            <span className="author">{author}</span>
-                            <span className="dot"></span>
-                            <span className="date">{formattedDate}</span>
-                        </div>
-
-                        <img src={cover?.toString()} className="cover" alt="Cover" />
-
-                        <hr className="divider" />
-
-                        <div className="markdown">
-                            {this.props.widgetFor("body")}
-                        </div>
-                    </div>
+                // Use Decap's renderer helpers to avoid loading a second React runtime.
+                return h(
+                    "div",
+                    { className: "blog" },
+                    h("h1", { className: "title" }, title || ""),
+                    h(
+                        "div",
+                        { className: "metadata" },
+                        h("span", { className: "author" }, author || ""),
+                        h("span", { className: "dot" }),
+                        h("span", { className: "date" }, formattedDate)
+                    ),
+                    h("img", {
+                        src: cover ? cover.toString() : "",
+                        className: "cover",
+                        alt: "Cover"
+                    }),
+                    h("hr", { className: "divider" }),
+                    h("div", { className: "markdown" }, this.props.widgetFor("body"))
                 );
             }
         });

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-    <script src="https://unpkg.com/decap-cms@3.0.0/dist/decap-cms.js"></script>
+    <script src="https://unpkg.com/decap-cms@^3/dist/decap-cms.js"></script>
 
     <!-- Decap CMS preview pane script -->
     <!-- Edit this script to customize the preview pane for your blog posts.  -->


### PR DESCRIPTION
Cabinets.jpg is used in more places than in the blog, so it shouldn't be removed when remove-decap.js is run