### PR TITLE
left cabinets.jpg alone when remove-decap.js is run

### DIFF
--- a/scripts/remove-decap.js
+++ b/scripts/remove-decap.js
@@ -167,9 +167,6 @@ function removeBlog() {
 	// Move blog images
 	moveItem("src/assets/images/blog", path.join(destinationDir, "images-blog"));
 
-	// Move cabinets.jpg (used as blog banner in post.html and blog.html)
-	moveItem("src/assets/images/cabinets.jpg", path.join(destinationDir, "cabinets.jpg"));
-
 	// Update header – remove blog <li> nav link
 	updateFile("src/_includes/sections/header.html", [
 		{

--- a/scripts/remove-demo.js
+++ b/scripts/remove-demo.js
@@ -114,8 +114,7 @@ function moveDemoImages() {
 	console.log("\n--- Moving demo images ---\n");
 	const dest = path.join(destinationDir, "images-demo");
 
-	// Note: cabinets.jpg is kept because blog templates (post.html, blog.html) use it as a banner image.
-	// It will be moved when remove-decap is run with blog removal.
+	// Note: cabinets.jpg is kept because it's used across the site
 	const images = ["landing.jpg", "construction.jpg"];
 	let count = 0;
 


### PR DESCRIPTION
Cabinets.jpg is used in more places than in the blog, so it shouldn't be removed when remove-decap.js is run